### PR TITLE
SIGTERM added to graceful close triggers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,7 @@ export default function enableGracefulClose(server, userOptions, callback) {
   }
 
   process.on('SIGINT', close);
+  process.on('SIGTERM', close);
 
   return close;
 }


### PR DESCRIPTION
Useful when stopping docker containers, `docker stop` sends SIGTERM by default.

@seeden please take a look